### PR TITLE
Typo in loan calculator index.html corrected

### DIFF
--- a/loancalculator/index.html
+++ b/loancalculator/index.html
@@ -36,7 +36,7 @@
               <div class="form-group">
                 <input type="number" class="form-control" id="years" placeholder="Years To Repay">
               </div>
-              <div class="forn-group">
+              <div class="form-group">
                 <input type="submit" value="Calculate" class="btn btn-dark btn-block">
               </div>
             </form>


### PR DESCRIPTION
Fixed a typo in loan calculator's  index.html at line 39.
Changed "forn"  to "form" .